### PR TITLE
Server config not propogating CreatePaths option

### DIFF
--- a/server.go
+++ b/server.go
@@ -205,6 +205,7 @@ func populateServerConfig(config *Config) *Config {
 		KeepAlive:                             config.KeepAlive,
 		MaxReceiveStreamFlowControlWindow:     maxReceiveStreamFlowControlWindow,
 		MaxReceiveConnectionFlowControlWindow: maxReceiveConnectionFlowControlWindow,
+		CreatePaths:                           config.CreatePaths,
 	}
 }
 


### PR DESCRIPTION
The value of `CreatePaths` in the Config is not forwarded in `populateServerConfig` meaning that the current implementation does not allow the server to enable path advertisement no matter what value is passed in via config in the `Listen*` functions.

closes #35